### PR TITLE
Update Hamburg DOP20 downloaders

### DIFF
--- a/src/orthophotos_downloader/data_scraping/wms_germany.py
+++ b/src/orthophotos_downloader/data_scraping/wms_germany.py
@@ -324,12 +324,12 @@ class BHV_RGB_Dop20_ImageDownloader(ImageDownloader):
         super().__init__(wms=wms, grid_spacing=grid_spacing)
 
 
-# Hamburg publishes two different DOP20 WMS services: "belaubt" (with leaves)
-# and "unbelaubt" (without leaves). Use the `leaves` parameter to select which
-# service to use when creating the downloader.
 class HH_RGB_Dop20_ImageDownloader(ImageDownloader):
-    """
-    A class for downloading images from the Hamburg DOP20 WMS service.
+    """A class for downloading images from the Hamburg DOP20 WMS service.
+
+    Hamburg publishes two different DOP20 WMS services: "belaubt" (with leaves)
+    and "unbelaubt" (without leaves). Use the `leaves` parameter to select which
+    service to use when creating the downloader.
 
     Args:
         grid_spacing: The grid spacing in meters for the image download.

--- a/src/orthophotos_downloader/data_scraping/wms_germany.py
+++ b/src/orthophotos_downloader/data_scraping/wms_germany.py
@@ -358,35 +358,6 @@ class HH_RGB_Dop20_ImageDownloader(ImageDownloader):
         super().__init__(wms=wms, grid_spacing=grid_spacing)
 
 
-class HH_CIR_Dop20_ImageDownloader(ImageDownloader):
-    """
-    A class for downloading images from the Hamburg DOP20 WMS service.
-    The WMS specifications are automatically set to the Hamburg DOP20 service.
-
-    Attributes:
-        grid_spacing: The grid spacing in meters for the image download.
-    """
-
-    def __init__(self, grid_spacing: int):
-        """
-        Initialize the HamburgDop20ImageDownloader.
-
-        Args:
-            grid_spacing: The grid spacing in meters for the image download.
-        """
-        # Define the parameters specific for the DOP20 WMS
-        wms = ExtendedWebMapService(
-            url="https://geodienste.hamburg.de/HH_WMS_DOP?language=ger&",
-            version="1.3.0",
-            resolution=0.2,
-            layer_name="CIR_DOP",
-            crs="EPSG:25832",
-            format="image/tiff",
-        )
-
-        super().__init__(wms=wms, grid_spacing=grid_spacing)
-
-
 class HE_RGB_Dop20_ImageDownloader(ImageDownloader):
     """
     A class for downloading images from the Hessen DOP20 WMS service.

--- a/src/orthophotos_downloader/data_scraping/wms_germany.py
+++ b/src/orthophotos_downloader/data_scraping/wms_germany.py
@@ -324,28 +324,33 @@ class BHV_RGB_Dop20_ImageDownloader(ImageDownloader):
         super().__init__(wms=wms, grid_spacing=grid_spacing)
 
 
+# Hamburg publishes two different DOP20 WMS services: "belaubt" (with leaves)
+# and "unbelaubt" (without leaves). Use the `leaves` parameter to select which
+# service to use when creating the downloader.
 class HH_RGB_Dop20_ImageDownloader(ImageDownloader):
     """
     A class for downloading images from the Hamburg DOP20 WMS service.
-    The WMS specifications are automatically set to the Hamburg DOP20 service.
 
-    Attributes:
+    Args:
         grid_spacing: The grid spacing in meters for the image download.
+        leaves: If True use the "belaubt" (with leaves) service, otherwise use
+            the "unbelaubt" (without leaves) service. Default: True.
     """
 
-    def __init__(self, grid_spacing: int):
-        """
-        Initialize the HamburgDop20ImageDownloader.
+    def __init__(self, grid_spacing: int, leaves: bool = True):
+        # choose service details based on leaves flag
+        if leaves:
+            url = "https://geodienste.hamburg.de/wms_dop_zeitreihe_belaubt?language=ger&"
+            layer = "dop_zeitreihe_belaubt"
+        else:
+            url = "https://geodienste.hamburg.de/wms_dop_zeitreihe_unbelaubt?language=ger&"
+            layer = "dop_zeitreihe_unbelaubt"
 
-        Args:
-            grid_spacing: The grid spacing in meters for the image download.
-        """
-        # Define the parameters specific for the DOP20 WMS
         wms = ExtendedWebMapService(
-            url="https://geodienste.hamburg.de/HH_WMS_DOP?language=ger&",
+            url=url,
             version="1.3.0",
             resolution=0.2,
-            layer_name="DOP",
+            layer_name=layer,
             crs="EPSG:25832",
             format="image/tiff",
         )

--- a/tests/download_test.py
+++ b/tests/download_test.py
@@ -118,6 +118,21 @@ def test_state_wms_download(state_info, output_path):
         assert rgb_count > 0, f"RGB download produced no images"
         print(f"   ✅ RGB: {rgb_count} images downloaded")
 
+        # additional test for Hamburg, which has a slightly different downloader, i.e. it has an
+        # additional leaves parameter (default=True) that needs to be tested with leaves=False as
+        # well
+        if state_name == "Hamburg":
+            rgb_downloader = rgb_class(grid_spacing=TILE_SIZE, leaves=False)
+            rgb_result = rgb_downloader.download_images_from_polygon(
+                area_name=state_name,
+                area_polygon=gdf_tile,
+                out_path=state_path,
+                filename_prefix="RGB",
+            )
+            rgb_count = len(rgb_result.images) if rgb_result else 0
+            assert rgb_count > 0, f"RGB download produced no images"
+            print(f"   ✅ RGB: {rgb_count} images downloaded")
+
     except AttributeError as e:
         if f"module '{wms_module.__name__}' has no attribute '{expected_rgb_cls}'" in str(e):
             print(f"   ⚠️  RGB downloader not implemented for {state_name}")

--- a/tests/download_test.py
+++ b/tests/download_test.py
@@ -105,7 +105,8 @@ def test_state_wms_download(state_info, output_path):
     # Test RGB download
     rgb_downloader = None
     try:
-        rgb_class = getattr(wms_module, f"{state_code}_RGB_Dop20_ImageDownloader")
+        expected_rgb_cls = f"{state_code}_RGB_Dop20_ImageDownloader"
+        rgb_class = getattr(wms_module, expected_rgb_cls)
         rgb_downloader = rgb_class(grid_spacing=TILE_SIZE)
         rgb_result = rgb_downloader.download_images_from_polygon(
             area_name=state_name,
@@ -116,6 +117,13 @@ def test_state_wms_download(state_info, output_path):
         rgb_count = len(rgb_result.images) if rgb_result else 0
         assert rgb_count > 0, f"RGB download produced no images"
         print(f"   ✅ RGB: {rgb_count} images downloaded")
+
+    except AttributeError as e:
+        if f"module '{wms_module.__name__}' has no attribute '{expected_rgb_cls}'" in str(e):
+            print(f"   ⚠️  RGB downloader not implemented for {state_name}")
+        else:
+            raise e
+
     except Exception as e:
         print(f"   ❌ RGB download failed: {e}")
         if is_critical:
@@ -126,7 +134,8 @@ def test_state_wms_download(state_info, output_path):
     # Test CIR download
     cir_downloader = None
     try:
-        cir_class = getattr(wms_module, f"{state_code}_CIR_Dop20_ImageDownloader")
+        expected_cir_cls = f"{state_code}_CIR_Dop20_ImageDownloader"
+        cir_class = getattr(wms_module, expected_cir_cls)
         cir_downloader = cir_class(grid_spacing=TILE_SIZE)
         cir_result = cir_downloader.download_images_from_polygon(
             area_name=state_name,
@@ -137,6 +146,13 @@ def test_state_wms_download(state_info, output_path):
         cir_count = len(cir_result.images) if cir_result else 0
         assert cir_count > 0, f"CIR download produced no images"
         print(f"   ✅ CIR: {cir_count} images downloaded")
+
+    except AttributeError as e:
+        if f"module '{wms_module.__name__}' has no attribute '{expected_cir_cls}'" in str(e):
+            print(f"   ⚠️  CIR downloader not implemented for {state_name}")
+        else:
+            raise e
+
     except Exception as e:
         print(f"   ❌ CIR download failed: {e}")
         if is_critical:


### PR DESCRIPTION
The DOP services for Hamburg [have changed](https://suche.transparenz.hamburg.de/dataset/digitale-orthophotos-hamburg9). The previously integrated services (RGB and CIR) in this repo have deen discontinued. There are two new recommended replacement services:
- [Luftbilder Hamburg DOP Zeitreihe belaubt](https://suche.transparenz.hamburg.de/dataset/luftbilder-hamburg-dop-zeitreihe-belaubt3)
- [Luftbilder Hamburg DOP Zeitreihe unbelaubt](https://suche.transparenz.hamburg.de/dataset/luftbilder-hamburg-dop-zeitreihe-unbelaubt5)

This PR updates the downloader classes for Hamburg accordingly.

- removed outdated CIR downloader for Hamburg (I could not find a replacement at the moment)
- updated `HH_RGB_Dop20_ImageDownloader` by adding a new boolean `leaves` parameter to control which of the above services will be used (defaults to `leaves=True`)
- updated the tests so both services are tested

Also I slightly changed the exception handling in the tests:
- previously non-existing downloader classes have raised an AttributeError which caused the test to fail for critical and to be marked as xfail (expected fail) for non-critical
- the problem with that is, that the for states which only have an RGB downloader class and no CIR downloader class, the whole test was marked as xfail, which is incorrect --> the test for RGB actually succeed and the test for CIR should not even have been executed
- I changed this behaviour by adding a distinct AttributeError handler which checks for non-existing downloader classes and just prints a message, that this class doesn't exists instead of marking the whole test for the current state as xfail

### Note on the new WMS:

The Hamburg DOP20 services are provided as time-series WMS layers. Each layer contains multiple orthophoto vintages that can be selected via the WMS `TIME` dimension. While it is possible to request a specific year (e.g. `TIME=2025`), this would permanently pin the downloader to that snapshot and require code changes whenever newer imagery becomes available. To ensure that the downloader always retrieves the latest orthophotos published by the provider, the `TIME` parameter is intentionally omitted. The WMS exposes a default time value that is maintained by the data provider and updated as new imagery is added, allowing consumers to automatically receive the most recent dataset without additional maintenance. The current default value as well as the list of available years can be found in the [service's `GetCapabilities` document](https://geodienste.hamburg.de/wms_dop_zeitreihe_unbelaubt?Service=WMS&Version=1.3.0&Request=GetCapabilities) under the layer's `TIME` dimension definition.